### PR TITLE
Get NativeWidget to compile under Xcode 12 GM

### DIFF
--- a/App/TestApplication/TestApplication.csproj
+++ b/App/TestApplication/TestApplication.csproj
@@ -27,6 +27,7 @@
         <MtouchLink>None</MtouchLink>
         <MtouchDebug>true</MtouchDebug>
         <CodesignKey>iPhone Developer</CodesignKey>
+        <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
         <DebugType>none</DebugType>
@@ -140,9 +141,10 @@
         </Compile>
         <Compile Include="FakeData.cs" />
 	
-	<AdditionalAppExtensions Include="/Users/donblas/Projects/xamarin-ios-swift-extension/SwiftExtension/TestNativeApp">
+	<AdditionalAppExtensions Include="$(MSBuildProjectDirectory)/../../Projects/xamarin-ios-swift-extension/SwiftExtension/TestNativeApp">
 		<Name>NativeWidgetExtension</Name>
-		<BuildOutput>DerivedData/TestNativeApp/Build/Products/Debug-iphoneos</BuildOutput>
+        <BuildOutput Condition="'$(Platform)' == 'iPhone'">build/Debug-iphoneos</BuildOutput>
+        <BuildOutput Condition="'$(Platform)' == 'iPhoneSimulator'">build/Debug-iphonesimulator</BuildOutput>
 	</AdditionalAppExtensions>
     </ItemGroup>
     <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/App/TestApplication/TestApplication.csproj
+++ b/App/TestApplication/TestApplication.csproj
@@ -141,10 +141,10 @@
         </Compile>
         <Compile Include="FakeData.cs" />
 	
-	<AdditionalAppExtensions Include="$(MSBuildProjectDirectory)/../../Projects/xamarin-ios-swift-extension/SwiftExtension/TestNativeApp">
+	<AdditionalAppExtensions Include="$(MSBuildProjectDirectory)/../../SwiftExtension/TestNativeApp">
 		<Name>NativeWidgetExtension</Name>
-        <BuildOutput Condition="'$(Platform)' == 'iPhone'">build/Debug-iphoneos</BuildOutput>
-        <BuildOutput Condition="'$(Platform)' == 'iPhoneSimulator'">build/Debug-iphonesimulator</BuildOutput>
+        <BuildOutput Condition="'$(Platform)' == 'iPhone'">DerivedData/TestNativeApp/Build/Products/Debug-iphoneos</BuildOutput>
+        <BuildOutput Condition="'$(Platform)' == 'iPhoneSimulator'">DerivedData/TestNativeApp/Build/Products/Debug-iphonesimulator</BuildOutput>
 	</AdditionalAppExtensions>
     </ItemGroup>
     <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # xamarin-ios-swift-extension
 Xamairn.iOS with Swift extension example project
+
+### Handy tips for building this project
+
+* Make sure your provisioning profile has an App Group
+* When building the TestNativeApp in Xcode, follow the [instructions listed here](https://docs.microsoft.com/en-us/xamarin/ios/platform/ios14/) to _enable a project relative output location_.

--- a/SwiftExtension/TestNativeApp/NativeWidget/NativeWidget.swift
+++ b/SwiftExtension/TestNativeApp/NativeWidget/NativeWidget.swift
@@ -10,12 +10,16 @@ import SwiftUI
 import Intents
 
 struct Provider: IntentTimelineProvider {
-    public func snapshot(for configuration: ConfigurationIntent, with context: Context, completion: @escaping (DataEntry) -> ()) {
+    public func placeholder(in context: Context) -> DataEntry {
+        return DataEntry(value: "0.0", delta: "0.0", date: Date(), configuration: Provider.Intent.init())
+    }
+    
+    public func getSnapshot(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (DataEntry) -> Void) {
         let entry = DataEntry(value: "0.0", delta: "0.0", date: Date(), configuration: configuration)
         completion(entry)
     }
-
-    public func timeline(for configuration: ConfigurationIntent, with context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+    
+    public func getTimeline(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (Timeline<DataEntry>) -> Void) {
         var entries: [DataEntry] = []
 
         let jsonData = readTestData();
@@ -31,6 +35,9 @@ struct Provider: IntentTimelineProvider {
         let timeline = Timeline(entries: entries, policy: .atEnd)
         completion(timeline)
     }
+    
+    typealias Entry = DataEntry
+    typealias Intent = ConfigurationIntent
 }
 
 struct DataEntry: TimelineEntry {
@@ -67,10 +74,11 @@ struct NativeWidget: Widget {
     private let kind: String = "NativeWidget"
 
     public var body: some WidgetConfiguration {
-        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider(), placeholder: PlaceholderView()) { entry in
+        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider()) { entry in
             NativeWidgetEntryView(entry: entry)
-        }
-        .configurationDisplayName("Xamarin.iOS Example")
-        .description("This is an example widget embedded in Xamarin.iOS Container.")
+            }
+            .configurationDisplayName("Xamarin.iOS Example")
+            .description("This is an example widget embedded in Xamarin.iOS Container.")
+            .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
     }
 }


### PR DESCRIPTION
Thanks for this sample. I have tried to get the widget to compile under Xcode 12 GM. This code works and I can launch the native app in the simulator with Xcode and see the widget all working (after I launched the Xamarin app first for the JSON file to have been created).

Please double check my swift code though I'm not 100% sure everything is correct.

Also it has been impossible to get the Xamarin iOS app with the widget building in Visual Studio Mac. I tried updating the csproj `AdditionalAppExtensions` section to no avail.

Would be greatly appreciated if these little issues can be ironed out :)